### PR TITLE
add directus-sync support

### DIFF
--- a/src/services/CoreSchemaProcessor.ts
+++ b/src/services/CoreSchemaProcessor.ts
@@ -776,7 +776,12 @@ export class CoreSchemaProcessor {
     return allFields.filter(field => {
       // Skip id field - we'll always add it
       if (field.field === 'id') return false;
-      
+
+      // fallback for directus-sync
+      if (field.meta === null) {
+        field.meta = {};
+      }
+
       // Include if field is explicitly marked as not a system field
       if (field.meta.system === false) return true;
       
@@ -878,7 +883,12 @@ export class CoreSchemaProcessor {
     const collection = this.snapshot.data.collections.find(
       c => c.collection === collectionName
     );
-    
+
+    // fallback for directus-sync
+    if(collection?.meta === null) {
+      collection.meta = {};
+    }
+
     return collection?.meta.singleton === true;
   }
 


### PR DESCRIPTION
First of all, thank you for this great extension! 
I am also using the very nice [directus-sync](https://github.com/tractr/directus-sync) extension for my dev workflow. Unfortunately the table generated by the extension is called `directus_sync` which is detected as an internal collection by directus-typeforge. 

I just needed this to work, so I hacked these two checks to the compiled cli.cjs locally, which is not very sustainable of course. It seems that the collection and fields `directus_sync` do not have the `meta` property. I have no idea why..

I did a brief check into the source of directus-typeforge to see where this modification would be better suited, but I did not find a good place. Maybe you know better where to add this support into your code, I just wanted to tell you that this would be a major quality of live feature for me and my team :D

If you tell me where to actually place this modification, I would change this PR of course.

Cheers ✌️