### PR TITLE
feat: add --typeMappings and --noSingularize options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,28 @@ directus-typeforge [options]
 
 ## Available Options
 
-| Option                      | Alias | Description                                                                | Default          |
-| --------------------------- | ----- | -------------------------------------------------------------------------- | ---------------- |
-| `--snapshotFile`            | `-i`  | Path to schema snapshot file                                               | -                |
-| `--host`                    | `-h`  | Directus host URL                                                          | -                |
-| `--email`                   | `-e`  | Email for authentication                                                   | -                |
-| `--password`                | `-p`  | Password for authentication                                                | -                |
-| `--token`                   | `-t`  | Admin bearer token for authentication                                      | -                |
-| `--outFile`                 | `-o`  | Output file for TypeScript types                                           | -                |
-| `--typeName`                | `-n`  | Root type name                                                             | `ApiCollections` |
-| `--useTypeReferences`       | `-r`  | Use interface references for relation types                                | `true`           |
-| `--useTypes`                | `-u`  | Use 'type' instead of 'interface'                                          | `false`          |
-| `--makeRequired`            | `-m`  | Make all fields required (no optional '?' syntax)                          | `true`           |
-| `--includeSystemFields`     | `-s`  | Include all system fields in system collections                            | `true`           |
-| `--exportSystemCollections` | `-x`  | Export system collections in root schema                                   | `true`           |
-| `--resolveSystemRelations`  | `-y`  | Resolve system collection relationships (e.g. directus_files.folder)       | `true`           |
-| `--addTypedocNotes`         | `-d`  | Add JSDoc comments from field notes                                        | `true`           |
-| `--timestamp`               |       | Include generation timestamp in output header                              | `false`          |
-| `--debug`                   |       | Enable debug logging                                                       | `false`          |
-| `--logLevel`                |       | Set log level (error, warn, info, debug, trace)                            | `info`           |
-| `--logFile`                 |       | Path to write debug logs                                                   |                  |
+| Option                      | Alias | Description                                                               | Default          |
+| --------------------------- | ----- | ------------------------------------------------------------------------- | ---------------- |
+| `--snapshotFile`            | `-i`  | Path to schema snapshot file                                              | -                |
+| `--host`                    | `-h`  | Directus host URL                                                         | -                |
+| `--email`                   | `-e`  | Email for authentication                                                  | -                |
+| `--password`                | `-p`  | Password for authentication                                               | -                |
+| `--token`                   | `-t`  | Admin bearer token for authentication                                     | -                |
+| `--outFile`                 | `-o`  | Output file for TypeScript types                                          | -                |
+| `--typeName`                | `-n`  | Root type name                                                            | `ApiCollections` |
+| `--useTypeReferences`       | `-r`  | Use interface references for relation types                               | `true`           |
+| `--useTypes`                | `-u`  | Use 'type' instead of 'interface'                                         | `false`          |
+| `--makeRequired`            | `-m`  | Make all fields required (no optional '?' syntax)                         | `true`           |
+| `--includeSystemFields`     | `-s`  | Include all system fields in system collections                           | `true`           |
+| `--exportSystemCollections` | `-x`  | Export system collections in root schema                                  | `true`           |
+| `--resolveSystemRelations`  | `-y`  | Resolve system collection relationships (e.g. directus_files.folder)      | `true`           |
+| `--addTypedocNotes`         | `-d`  | Add JSDoc comments from field notes                                       | `true`           |
+| `--typeMappings`            |       | Custom collection-to-type mappings (e.g. `kurs:Kurs,ausweis:Ausweis`)     | -                |
+| `--noSingularize`           |       | Disable automatic singularization of collection names                     | `false`          |
+| `--timestamp`               |       | Include generation timestamp in output header                             | `false`          |
+| `--debug`                   |       | Enable debug logging                                                      | `false`          |
+| `--logLevel`                |       | Set log level (error, warn, info, debug, trace)                           | `info`           |
+| `--logFile`                 |       | Path to write debug logs                                                  |                  |
 
 **only disable `--useTypeReferences` for very specific debugging, it will make
 all of your relational types break.**
@@ -127,6 +129,12 @@ npx directus-typeforge -i schema-snapshot.json -u -o ./types/schema.ts
 
 # Include generation timestamp in output header
 npx directus-typeforge -i schema-snapshot.json --timestamp -o ./types/schema.ts
+
+# Custom type mappings (useful for non-English collection names)
+npx directus-typeforge -i schema-snapshot.json --typeMappings "kurs:Kurs,ausweis:Ausweis" -o ./types/schema.ts
+
+# Disable singularization entirely (useful for non-English projects)
+npx directus-typeforge -i schema-snapshot.json --noSingularize -o ./types/schema.ts
 
 # Enable debug logging to troubleshoot issues
 npx directus-typeforge -i schema-snapshot.json --debug --logLevel debug --logFile ./typeforge-debug.log -o ./types/schema.ts

--- a/README.md
+++ b/README.md
@@ -58,28 +58,28 @@ directus-typeforge [options]
 
 ## Available Options
 
-| Option                      | Alias | Description                                                               | Default          |
-| --------------------------- | ----- | ------------------------------------------------------------------------- | ---------------- |
-| `--snapshotFile`            | `-i`  | Path to schema snapshot file                                              | -                |
-| `--host`                    | `-h`  | Directus host URL                                                         | -                |
-| `--email`                   | `-e`  | Email for authentication                                                  | -                |
-| `--password`                | `-p`  | Password for authentication                                               | -                |
-| `--token`                   | `-t`  | Admin bearer token for authentication                                     | -                |
-| `--outFile`                 | `-o`  | Output file for TypeScript types                                          | -                |
-| `--typeName`                | `-n`  | Root type name                                                            | `ApiCollections` |
-| `--useTypeReferences`       | `-r`  | Use interface references for relation types                               | `true`           |
-| `--useTypes`                | `-u`  | Use 'type' instead of 'interface'                                         | `false`          |
-| `--makeRequired`            | `-m`  | Make all fields required (no optional '?' syntax)                         | `true`           |
-| `--includeSystemFields`     | `-s`  | Include all system fields in system collections                           | `true`           |
-| `--exportSystemCollections` | `-x`  | Export system collections in root schema                                  | `true`           |
-| `--resolveSystemRelations`  | `-y`  | Resolve system collection relationships (e.g. directus_files.folder)      | `true`           |
-| `--addTypedocNotes`         | `-d`  | Add JSDoc comments from field notes                                       | `true`           |
-| `--typeMappings`            |       | Custom collection-to-type mappings (e.g. `kurs:Kurs,ausweis:Ausweis`)     | -                |
-| `--noSingularize`           |       | Disable automatic singularization of collection names                     | `false`          |
-| `--timestamp`               |       | Include generation timestamp in output header                             | `false`          |
-| `--debug`                   |       | Enable debug logging                                                      | `false`          |
-| `--logLevel`                |       | Set log level (error, warn, info, debug, trace)                           | `info`           |
-| `--logFile`                 |       | Path to write debug logs                                                  |                  |
+| Option                      | Alias | Description                                                                | Default          |
+| --------------------------- | ----- |----------------------------------------------------------------------------| ---------------- |
+| `--snapshotFile`            | `-i`  | Path to schema snapshot file                                               | -                |
+| `--host`                    | `-h`  | Directus host URL                                                          | -                |
+| `--email`                   | `-e`  | Email for authentication                                                   | -                |
+| `--password`                | `-p`  | Password for authentication                                                | -                |
+| `--token`                   | `-t`  | Admin bearer token for authentication                                      | -                |
+| `--outFile`                 | `-o`  | Output file for TypeScript types                                           | -                |
+| `--typeName`                | `-n`  | Root type name                                                             | `ApiCollections` |
+| `--useTypeReferences`       | `-r`  | Use interface references for relation types                                | `true`           |
+| `--useTypes`                | `-u`  | Use 'type' instead of 'interface'                                          | `false`          |
+| `--makeRequired`            | `-m`  | Make all fields required (no optional '?' syntax)                          | `true`           |
+| `--includeSystemFields`     | `-s`  | Include all system fields in system collections                            | `true`           |
+| `--exportSystemCollections` | `-x`  | Export system collections in root schema                                   | `true`           |
+| `--resolveSystemRelations`  | `-y`  | Resolve system collection relationships (e.g. directus_files.folder)       | `true`           |
+| `--addTypedocNotes`         | `-d`  | Add JSDoc comments from field notes                                        | `true`           |
+| `--typeMappings`            |       | Custom collection-to-type mappings (e.g. `kurs:Kurs,ausweis:Ausweis`)      | -                |
+| `--noSingularize`           |       | Disable automatic singularization of collection names                      | `false`          |
+| `--timestamp`               |       | Include generation timestamp in output header                              | `false`          |
+| `--debug`                   |       | Enable debug logging                                                       | `false`          |
+| `--logLevel`                |       | Set log level (error, warn, info, debug, trace)                            | `info`           |
+| `--logFile`                 |       | Path to write debug logs                                                   |                  |
 
 **only disable `--useTypeReferences` for very specific debugging, it will make
 all of your relational types break.**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,15 @@ const main = async (): Promise<void> => {
       description: "Include generation timestamp in output header",
       default: false,
     })
+    .option("typeMappings", {
+      type: "string",
+      description: "Custom collection-to-type mappings (e.g. kurs:Kurs,ausweis:Ausweis)",
+    })
+    .option("noSingularize", {
+      type: "boolean",
+      description: "Disable automatic singularization of collection names",
+      default: false,
+    })
     .option("debug", {
       type: "boolean",
       description: "Enable debug logging",
@@ -215,6 +224,17 @@ const main = async (): Promise<void> => {
       token: argv.token,
     };
 
+    // Parse type mappings from CLI string format (e.g. "kurs:Kurs,kurse:Kurse")
+    const typeMappings: Record<string, string> = {};
+    if (argv.typeMappings) {
+      for (const pair of argv.typeMappings.split(",")) {
+        const [collection, typeName] = pair.split(":");
+        if (collection && typeName) {
+          typeMappings[collection.trim()] = typeName.trim();
+        }
+      }
+    }
+
     // Generate TypeScript types with dynamic system field detection
     spinner.text = "Generating TypeScript types...";
     const ts = await generateTypeScript(
@@ -230,6 +250,8 @@ const main = async (): Promise<void> => {
         resolveSystemRelations: argv.resolveSystemRelations,
         addTypedocNotes: argv.addTypedocNotes,
         includeTimestamp: argv.timestamp,
+        typeMappings: Object.keys(typeMappings).length > 0 ? typeMappings : undefined,
+        noSingularize: argv.noSingularize,
       },
       schemaOptions
     );

--- a/src/services/CoreSchemaProcessor.ts
+++ b/src/services/CoreSchemaProcessor.ts
@@ -77,6 +77,8 @@ export class CoreSchemaProcessor {
       resolveSystemRelations: options.resolveSystemRelations ?? true,
       addTypedocNotes: options.addTypedocNotes ?? true,
       includeTimestamp: options.includeTimestamp ?? false,
+      typeMappings: options.typeMappings ?? {},
+      noSingularize: options.noSingularize ?? false,
     };
 
     // Initialize component managers
@@ -1013,6 +1015,13 @@ export class CoreSchemaProcessor {
       return typeName;
     }
     
+    // Check custom type mappings first
+    if (this.options.typeMappings && collectionName in this.options.typeMappings) {
+      const typeName = this.options.typeMappings[collectionName];
+      this.collectionTypes.set(collectionName, typeName);
+      return typeName;
+    }
+
     // For regular collections, convert to PascalCase singular (unless it's a singleton)
     const isSingletonCollection = this.isSingleton(collectionName);
     const pascalName = toPascalCase(collectionName);
@@ -1038,6 +1047,7 @@ export class CoreSchemaProcessor {
    * Convert plural to singular using pluralize library
    */
   private makeSingular(name: string): string {
+    if (this.options.noSingularize) return name;
     return pluralize.singular(name);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ export type GenerateTypeScriptOptions = {
   resolveSystemRelations?: boolean; // Resolve system collection internal relationships (e.g. directus_files.folder -> DirectusFolder)
   addTypedocNotes?: boolean;       // Add JSDoc comments from field notes
   includeTimestamp?: boolean;      // Include generation timestamp in output header (default: false)
+  typeMappings?: Record<string, string>; // Custom collection name to type name mappings (e.g. { "kurs": "Kurs" })
+  noSingularize?: boolean;              // Disable automatic singularization of collection names
 };
 
 /**


### PR DESCRIPTION
The `pluralize` library assumes English, which breaks non-English collection names ending in "s" (e.g. `"kurs"` → `"Kur"` instead of `"Kurs"`).

`--typeMappings` allows explicit collection-to-type overrides. `--noSingularize` disables singularization entirely.

Closes #18